### PR TITLE
Move some tensors to device to fix odd errors

### DIFF
--- a/openmmml/models/macepotential.py
+++ b/openmmml/models/macepotential.py
@@ -143,6 +143,7 @@ class MACEPotentialImpl(MLPotentialImpl):
 
                 self.model = torch.load(model_path, map_location=device)
                 self.model.to(self.default_dtype)
+                self.model.to(self.device)
                 self.model.eval()
 
                 # print(self.model)
@@ -153,6 +154,7 @@ class MACEPotentialImpl(MLPotentialImpl):
                 self.z_table = utils.AtomicNumberTable(
                     [int(z) for z in self.model.atomic_numbers]
                 )
+                self.model.atomic_numbers = torch.tensor(self.model.atomic_numbers.clone(), device=self.device)
 
                 self.model = jit.compile(self.model)
 
@@ -179,7 +181,7 @@ class MACEPotentialImpl(MLPotentialImpl):
                 if indices is None:
                     self.indices = None
                 else:
-                    self.indices = torch.tensor(indices, dtype=torch.int64)
+                    self.indices = torch.tensor(indices, dtype=torch.int64, device=self.device)
 
             def forward(self, positions, boxvectors: Optional[torch.Tensor] = None):
                 # setup positions


### PR DESCRIPTION
As I said, when I was using topologies derived from pymatgen structures some tensors were not being allocated to device properly. If I recall correctly, the problem was with `self.model.atomic_numbers`. When I manually allocated the tensor to device it solved the problem. The other two changes were just to be safe.


This is how I made the Pymatgen structures:

```python
def structure_to_topology(structure: Structure) -> openmm.app.Topology:
    """Convert pymatgen structure to openmm topology.

    Args:
        structure (Structure): The pymatgen structure to convert.

    Returns:
        openmm.app.Topology: The converted OpenMM topology.
    """
    top = Topology()
    chain = top.addChain()
    for i, site in enumerate(structure):
        res = top.addResidue(f"r{i}", chain)
        element = openmm.app.element.Element.getBySymbol(site.species_string)
        top.addAtom(f"{element}{i}", element, res)
    return top
```